### PR TITLE
feat(practice4): added oauth2 and keycloak

### DIFF
--- a/infrastructure/destroy.sh
+++ b/infrastructure/destroy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+kubectl delete -f subscriptions-postgres-statefulset.yaml
+kubectl delete -f notifications-postgres-statefulset.yaml
+
+kubectl delete -f subscriptions-postgres-service.yaml
+kubectl delete -f notifications-postgres-service.yaml
+
+kubectl delete -f subscriptions-api-deployment.yaml
+kubectl delete -f notifications-api-deployment.yaml
+
+kubectl delete -f subscriptions-api-service.yaml
+kubectl delete -f notifications-api-service.yaml
+
+kubectl delete -f keycloak-deployment.yaml
+kubectl delete -f keycloak-service.yaml
+
+kubectl delete -f oauth2-proxy-deployment.yaml
+kubectl delete -f oauth2-proxy-service.yaml
+
+kubectl delete -f ingress.yaml
+kubectl delete -f keycloak-ingress.yaml
+
+echo "All resources deleted"

--- a/infrastructure/ingress.yaml
+++ b/infrastructure/ingress.yaml
@@ -5,12 +5,21 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.default.svc.cluster.local/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "http://oauth2-proxy.default.svc.cluster.local/oauth2/start?rd=$escaped_request_uri"
 spec:
   ingressClassName: nginx
   rules:
     - host: microservices.local
       http:
         paths:
+          - path: /oauth2(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 80
           - path: /notifications(/|$)(.*)
             pathType: ImplementationSpecific
             backend:
@@ -18,7 +27,6 @@ spec:
                 name: notifications-api
                 port:
                   number: 5179
-                  
           - path: /subscriptions(/|$)(.*)
             pathType: ImplementationSpecific
             backend:

--- a/infrastructure/keycloak-deployment.yaml
+++ b/infrastructure/keycloak-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+      - name: keycloak
+        image: quay.io/keycloak/keycloak:26.2.0
+        args: ["start-dev", "--hostname-strict=false"]
+        ports:
+        - containerPort: 8080
+        env:
+          - name: KEYCLOAK_ADMIN
+            value: "admin"
+          - name: KEYCLOAK_ADMIN_PASSWORD
+            value: "admin"

--- a/infrastructure/keycloak-ingress.yaml
+++ b/infrastructure/keycloak-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: keycloak-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: keycloak.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: keycloak
+                port:
+                  number: 8080
+

--- a/infrastructure/keycloak-service.yaml
+++ b/infrastructure/keycloak-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+spec:
+  selector:
+    app: keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+

--- a/infrastructure/notifications-api-deployment.yaml
+++ b/infrastructure/notifications-api-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: notifications-api
-        image: infrastructure-notifications-api:latest
+        image: infrastructure_notifications-api:latest
         imagePullPolicy: Never
         ports:
         - containerPort: 5179

--- a/infrastructure/oauth2-proxy-deployment.yaml
+++ b/infrastructure/oauth2-proxy-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app: oauth2-proxy
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        args:
+          - --provider=keycloak-oidc
+          - --client-id=notiffly
+          - --client-secret=cr06sjskqhCtysk0kW9yMMP2l1pH7Uov
+          - --redirect-url=https://microservices.local/oauth2/callback
+          - --oidc-issuer-url=http://keycloak.default.svc.cluster.local:8080/realms/notiffly
+          - --cookie-secure=false
+          - --email-domain=*
+          - --code-challenge-method=S256
+          - --cookie-secret=95df60dd5c7af0a9171c4822c06b0881
+        ports:
+          - containerPort: 4180

--- a/infrastructure/oauth2-proxy-service.yaml
+++ b/infrastructure/oauth2-proxy-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth2-proxy
+spec:
+  ports:
+    - port: 80
+      targetPort: 4180
+  selector:
+    app: oauth2-proxy

--- a/infrastructure/setup.sh
+++ b/infrastructure/setup.sh
@@ -12,6 +12,13 @@ kubectl apply -f notifications-api-deployment.yaml
 kubectl apply -f subscriptions-api-service.yaml
 kubectl apply -f notifications-api-service.yaml
 
+kubectl apply -f keycloak-deployment.yaml
+kubectl apply -f keycloak-service.yaml
+
+kubectl apply -f oauth2-proxy-deployment.yaml
+kubectl apply -f oauth2-proxy-service.yaml
+
 kubectl apply -f ingress.yaml
+kubectl apply -f keycloak-ingress.yaml
 
 echo "All resources applied"

--- a/infrastructure/subscriptions-api-deployment.yaml
+++ b/infrastructure/subscriptions-api-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: subscriptions-api
-        image: infrastructure-subscriptions-api:latest
+        image: infrastructure_subscriptions-api:latest
         imagePullPolicy: Never
         ports:
         - containerPort: 5177


### PR DESCRIPTION
This commit adds Keycloak integration for authentication. It connects the application to Keycloak to verify user tokens. The code uses simple settings for secure login. Now, the service only allows authorized users to access protected routes.